### PR TITLE
Ensure max testdata range is in bounds

### DIFF
--- a/storage_test.go
+++ b/storage_test.go
@@ -237,7 +237,7 @@ func test(t *testing.T, s testDB) (panicked error) {
 	}
 
 	max := len(testdata)
-	if n := *oM; n != 0 {
+	if n := *oM; n != 0 && n < max {
 		max = n
 	}
 	for itest, test := range testdata[*oN:max] {


### PR DESCRIPTION
The complete test suite times out on my machine, so I need to chunk up the test cases. This change makes it easy to not fail because of an index out of range without first checking testdata.ql.