### PR TITLE
Fix panic on select after adding a column to a table.

### DIFF
--- a/file.go
+++ b/file.go
@@ -767,6 +767,9 @@ func (s *file) free(h int64, blobCols []*col) (err error) {
 		if col.index >= len(rec) {
 			return fmt.Errorf("(file-004) file.free: corrupted DB (record len)")
 		}
+		if !(len(rec) > col.index+2) {
+			break
+		}
 
 		switch x := rec[col.index+2].(type) {
 		case nil:
@@ -796,6 +799,9 @@ func (s *file) Read(dst []interface{}, h int64, cols ...*col) (data []interface{
 
 	for _, col := range cols {
 		i := col.index + 2
+		if !(len(rec) > i) {
+			break
+		}
 		switch col.typ {
 		case 0:
 		case qBool:

--- a/testdata.ql
+++ b/testdata.ql
@@ -9723,3 +9723,13 @@ COMMIT;
 SELECT formatInt(c, 18) FROM t;
 |s
 [26]
+
+-- 808
+BEGIN TRANSACTION;
+        CREATE TABLE t (i int);
+        INSERT INTO t VALUES(42);
+        ALTER TABLE t ADD b blob;
+COMMIT;
+SELECT * FROM t;
+|li, ?b
+[42 <nil>]


### PR DESCRIPTION
This is similar to #31 but it wasn't covered as it wasn't matching any case in
the switch inside file.Read as the type added to the table was a string. Doing
the same with a type like complex64, float32, int8, int16, int32, uint8,
uint16, uint32, blob, bigint, bigrat, time, duration will trigger a panic.