### PR TITLE
Fix update after alter table adding a blob type.

### DIFF
--- a/file.go
+++ b/file.go
@@ -988,6 +988,9 @@ func (s *file) UpdateRow(h int64, blobCols []*col, data ...interface{}) (err err
 	}
 
 	for _, c := range blobCols {
+		if !(len(data0) > c.index+2) {
+			break
+		}
 		if x := data0[c.index+2]; x != nil {
 			if err = s.freeChunks(x.(chunk).b); err != nil {
 				return

--- a/testdata.ql
+++ b/testdata.ql
@@ -9723,3 +9723,13 @@ COMMIT;
 SELECT formatInt(c, 18) FROM t;
 |s
 [26]
+-- 809
+BEGIN TRANSACTION;
+        CREATE TABLE t (i int);
+        INSERT INTO t VALUES(42);
+        ALTER TABLE t ADD b blob;
+        UPDATE t b = blob("a");
+COMMIT;
+SELECT * FROM t;
+|li, ?b
+[42 [97]]


### PR DESCRIPTION
(this needs to be rebased changing also the tests numbers if #92 lands before).

This is similar to #68 but it fixes a panic after adding a blob type (also time
type and every other type saved as a blob).

Note: if using the provided test without the fix, the tests will enter an infinite loop in ql.go:1869 due to pc != db.cc.
Now I haven't looked why this happened. Looks like after panicking a commit or
another operation is done causing bad behavior.
Additionally aren't pc and db.cc pointers to TCtx and the equality check should
be done between their referenced values? (*pc != *db.cc)?