### PR TITLE
file.go: Update the camlistore/lock to camlistore/go4/lock.

### DIFF
--- a/file.go
+++ b/file.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/camlistore/lock"
+	"github.com/camlistore/go4/lock"
 	"github.com/cznic/exp/lldb"
 	"github.com/cznic/mathutil"
 )


### PR DESCRIPTION
@cznic The camlistore/lock is deprecated. The new package also fixed a lock bug (https://github.com/camlistore/go4/pull/7).
