### PR TITLE
Implement dummy table support 

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/cznic/strutil"
-	"github.com/kr/pretty"
 )
 
 // Note: All benchmarks report MB/s equal to record/s.
@@ -2755,7 +2754,7 @@ func testMentionedColumns(s stmt) (err error) {
 			case error:
 				err = x
 			default:
-				err = fmt.Errorf("error: %v\n%s", e, pretty.Sprint(s))
+				err = fmt.Errorf("error: %v", e)
 			}
 		}
 	}()

--- a/all_test.go
+++ b/all_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cznic/strutil"
+	"github.com/kr/pretty"
 )
 
 // Note: All benchmarks report MB/s equal to record/s.
@@ -2754,7 +2755,7 @@ func testMentionedColumns(s stmt) (err error) {
 			case error:
 				err = x
 			default:
-				err = fmt.Errorf("error: %v", e)
+				err = fmt.Errorf("error: %v\n%s", e, pretty.Sprint(s))
 			}
 		}
 	}()
@@ -2802,7 +2803,14 @@ func testMentionedColumns(s stmt) (err error) {
 			}
 		}
 		if w := x.where; w != nil {
-			mentionedColumns(w.expr)
+			if e := w.expr; e != nil {
+				mentionedColumns(w.expr)
+			}
+			if s := w.sel; s != nil {
+				if err := testMentionedColumns(s); err != nil {
+					return err
+				}
+			}
 		}
 	case *updateStmt:
 		for _, v := range x.list {

--- a/plan.go
+++ b/plan.go
@@ -2807,7 +2807,7 @@ type selectDummyPlan struct {
 func (r *selectDummyPlan) hasID() bool { return true }
 
 func (r *selectDummyPlan) explain(w strutil.Formatter) {
-	w.Format("┌Iselects values from dummy table\n└Output field names %v\n", qnames(r.fieldNames()))
+	w.Format("┌Selects values from dummy table\n└Output field names %v\n", qnames(r.fieldNames()))
 }
 
 func (r *selectDummyPlan) fieldNames() []string { return make([]string, len(r.fields)) }

--- a/plan.go
+++ b/plan.go
@@ -2807,7 +2807,7 @@ type selectDummyPlan struct {
 func (r *selectDummyPlan) hasID() bool { return true }
 
 func (r *selectDummyPlan) explain(w strutil.Formatter) {
-	// w.Format("┌Iterate all rows of table %q\n└Output field names %v\n", r.t.name, qnames(r.fieldNames()))
+	w.Format("┌Iselects values from dummy table\n└Output field names %v\n", qnames(r.fieldNames()))
 }
 
 func (r *selectDummyPlan) fieldNames() []string { return make([]string, len(r.fields)) }

--- a/plan.go
+++ b/plan.go
@@ -49,6 +49,7 @@ var (
 	_ plan = (*selectFieldsDefaultPlan)(nil)
 	_ plan = (*selectFieldsGroupPlan)(nil)
 	_ plan = (*selectIndexDefaultPlan)(nil)
+	_ plan = (*selectDummyPlan)(nil)
 	_ plan = (*sysColumnDefaultPlan)(nil)
 	_ plan = (*sysIndexDefaultPlan)(nil)
 	_ plan = (*sysTableDefaultPlan)(nil)
@@ -2797,4 +2798,25 @@ func (r *fullJoinDefaultPlan) do(ctx *execCtx, f func(id interface{}, data []int
 			return err
 		}
 	}
+}
+
+type selectDummyPlan struct {
+	fields []interface{}
+}
+
+func (r *selectDummyPlan) hasID() bool { return true }
+
+func (r *selectDummyPlan) explain(w strutil.Formatter) {
+	// w.Format("┌Iterate all rows of table %q\n└Output field names %v\n", r.t.name, qnames(r.fieldNames()))
+}
+
+func (r *selectDummyPlan) fieldNames() []string { return make([]string, len(r.fields)) }
+
+func (r *selectDummyPlan) filter(expr expression) (plan, []string, error) {
+	return nil, nil, nil
+}
+
+func (r *selectDummyPlan) do(ctx *execCtx, f func(id interface{}, data []interface{}) (bool, error)) (err error) {
+	_, err = f(nil, r.fields)
+	return
 }

--- a/plan.go
+++ b/plan.go
@@ -35,6 +35,7 @@ const (
 var (
 	_ plan = (*crossJoinDefaultPlan)(nil)
 	_ plan = (*distinctDefaultPlan)(nil)
+	_ plan = (*emptyFieldsPlan)(nil)
 	_ plan = (*explainDefaultPlan)(nil)
 	_ plan = (*filterDefaultPlan)(nil)
 	_ plan = (*fullJoinDefaultPlan)(nil)
@@ -2818,5 +2819,18 @@ func (r *selectDummyPlan) filter(expr expression) (plan, []string, error) {
 
 func (r *selectDummyPlan) do(ctx *execCtx, f func(id interface{}, data []interface{}) (bool, error)) (err error) {
 	_, err = f(nil, r.fields)
+	return
+}
+
+type emptyFieldsPlan struct {
+	*nullPlan
+}
+
+func (r *emptyFieldsPlan) do(ctx *execCtx, f func(id interface{}, data []interface{}) (bool, error)) (err error) {
+	v := make([]interface{}, len(r.fields))
+	for i := range v {
+		v[i] = ""
+	}
+	_, err = f(nil, v)
 	return
 }

--- a/ql.go
+++ b/ql.go
@@ -337,13 +337,12 @@ type whereRset struct {
 }
 
 func (r *whereRset) String() string {
-	s := ""
 	if r.sel != nil {
-		if r.exists {
-			s += " EXISTS "
+		s := ""
+		if !r.exists {
+			s += " NOT "
 		}
-		s += "(" + strings.TrimSuffix(r.sel.String(), ";") + ")"
-		return s
+		return fmt.Sprintf("%s EXISTS ( %s )", s, strings.TrimSuffix(r.sel.String(), ";"))
 	}
 	return r.expr.String()
 }

--- a/ql.go
+++ b/ql.go
@@ -1616,6 +1616,9 @@ type joinRset struct {
 }
 
 func (r *joinRset) String() string {
+	if len(r.sources) == 0 {
+		return ""
+	}
 	a := make([]string, len(r.sources))
 	for i, pair0 := range r.sources {
 		pair := pair0.([]interface{})
@@ -1658,6 +1661,9 @@ func (r *joinRset) String() string {
 }
 
 func (r *joinRset) plan(ctx *execCtx) (plan, error) {
+	if len(r.sources) == 0 {
+		return nil, nil
+	}
 	rsets := make([]plan, len(r.sources))
 	names := make([]string, len(r.sources))
 	var err error

--- a/ql.go
+++ b/ql.go
@@ -537,7 +537,7 @@ func (r *whereRset) plan(ctx *execCtx) (plan, error) {
 			if len(data) > 0 {
 				exists = true
 			}
-			return true, nil
+			return false, nil
 		})
 		if err != nil {
 			return nil, err

--- a/ql.go
+++ b/ql.go
@@ -550,6 +550,7 @@ func (r *whereRset) plan(ctx *execCtx) (plan, error) {
 	}
 	return r.planExpr(ctx)
 }
+
 func (r *whereRset) planExpr(ctx *execCtx) (plan, error) {
 	if r.expr == nil {
 		return &nullPlan{}, nil

--- a/ql.go
+++ b/ql.go
@@ -1615,8 +1615,13 @@ type joinRset struct {
 	on      expression
 }
 
+func (r *joinRset) isZero() bool {
+	return len(r.sources) == 0 && r.typ == 0 && !valid(r.on)
+
+}
+
 func (r *joinRset) String() string {
-	if len(r.sources) == 0 {
+	if r.isZero() {
 		return ""
 	}
 	a := make([]string, len(r.sources))
@@ -1661,7 +1666,7 @@ func (r *joinRset) String() string {
 }
 
 func (r *joinRset) plan(ctx *execCtx) (plan, error) {
-	if len(r.sources) == 0 {
+	if r.isZero() {
 		return nil, nil
 	}
 	rsets := make([]plan, len(r.sources))

--- a/ql.go
+++ b/ql.go
@@ -1616,7 +1616,7 @@ type joinRset struct {
 }
 
 func (r *joinRset) isZero() bool {
-	return len(r.sources) == 0 && r.typ == 0 && !valid(r.on)
+	return len(r.sources) == 0 && r.typ == 0 && r.on == nil
 
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -750,8 +750,14 @@ func (s *selectStmt) String() string {
 		}
 		b.WriteString(" " + strings.Join(a, ", "))
 	}
-	b.WriteString(" FROM ")
-	b.WriteString(s.from.String())
+	if s.from != nil {
+		j := s.from.String()
+		if strings.TrimSpace(j) != "" {
+			b.WriteString(" FROM ")
+			b.WriteString(j)
+		}
+	}
+
 	if s.where != nil {
 		b.WriteString(" WHERE ")
 		b.WriteString(s.where.expr.String())

--- a/stmt.go
+++ b/stmt.go
@@ -759,7 +759,7 @@ func (s *selectStmt) String() string {
 
 	if s.where != nil {
 		b.WriteString(" WHERE ")
-		b.WriteString(s.where.expr.String())
+		b.WriteString(s.where.String())
 	}
 	if s.group != nil {
 		b.WriteString(" GROUP BY ")
@@ -800,7 +800,7 @@ func (s *selectStmt) plan(ctx *execCtx) (plan, error) { //LATER overlapping goro
 		r = &selectDummyPlan{fields: fds}
 	}
 	if w := s.where; w != nil {
-		if r, err = (&whereRset{expr: w.expr, src: r}).plan(ctx); err != nil {
+		if r, err = (&whereRset{expr: w.expr, src: r, sel: w.sel, exists: w.exists}).plan(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"reflect"
-
 	"github.com/cznic/strutil"
 )
 
@@ -781,10 +779,6 @@ func (s *selectStmt) String() string {
 	}
 	b.WriteRune(';')
 	return b.String()
-}
-
-func valid(v interface{}) bool {
-	return reflect.ValueOf(v).IsValid()
 }
 
 func (s *selectStmt) plan(ctx *execCtx) (plan, error) { //LATER overlapping goroutines/pipelines

--- a/stmt.go
+++ b/stmt.go
@@ -787,7 +787,15 @@ func (s *selectStmt) plan(ctx *execCtx) (plan, error) { //LATER overlapping goro
 	if err != nil {
 		return nil, err
 	}
-
+	if r == nil {
+		var fds []interface{}
+		for _, v := range s.flds {
+			if val, ok := v.expr.(value); ok {
+				fds = append(fds, val)
+			}
+		}
+		r = &selectDummyPlan{fields: fds}
+	}
 	if w := s.where; w != nil {
 		if r, err = (&whereRset{expr: w.expr, src: r}).plan(ctx); err != nil {
 			return nil, err

--- a/testdata.log
+++ b/testdata.log
@@ -8403,3 +8403,17 @@ SELECT 42;
 ┌Evaluate 42 as "",
 └Output field names [""]
 
+---- 1348
+SELECT * FROM t WHERE  EXISTS (SELECT * FROM t WHERE i == 2);
+┌Iterate all rows of table "t"
+└Output field names ["i"]
+┌Filter on i == 2
+│Possibly useful indices
+│CREATE INDEX xt_i ON t(i);
+└Output field names ["i"]
+
+---- 1349
+SELECT * FROM t WHERE  EXISTS (SELECT * FROM t WHERE i == 2);
+┌Iterate no rows
+└Output field names ["i"]
+

--- a/testdata.log
+++ b/testdata.log
@@ -8396,3 +8396,8 @@ SELECT * FROM t WHERE c1 == 1;
 │CREATE INDEX xt_c1 ON t(c1);
 └Output field names ["c1" "c2"]
 
+---- 1347
+SELECT 42;
+┌Evaluate 42 as "",
+└Output field names [""]
+

--- a/testdata.log
+++ b/testdata.log
@@ -8404,7 +8404,7 @@ SELECT 42;
 └Output field names [""]
 
 ---- 1348
-SELECT * FROM t WHERE  EXISTS (SELECT * FROM t WHERE i == 2);
+SELECT * FROM t WHERE  EXISTS ( SELECT * FROM t WHERE i == 2 );
 ┌Iterate all rows of table "t"
 └Output field names ["i"]
 ┌Filter on i == 2
@@ -8413,7 +8413,7 @@ SELECT * FROM t WHERE  EXISTS (SELECT * FROM t WHERE i == 2);
 └Output field names ["i"]
 
 ---- 1349
-SELECT * FROM t WHERE  EXISTS (SELECT * FROM t WHERE i == 2);
+SELECT * FROM t WHERE  EXISTS ( SELECT * FROM t WHERE i == 2 );
 ┌Iterate no rows
 └Output field names ["i"]
 

--- a/testdata.log
+++ b/testdata.log
@@ -8398,7 +8398,7 @@ SELECT * FROM t WHERE c1 == 1;
 
 ---- 1347
 SELECT 42;
-┌Iselects values from dummy table
+┌Selects values from dummy table
 └Output field names [""]
 ┌Evaluate 42 as "",
 └Output field names [""]

--- a/testdata.log
+++ b/testdata.log
@@ -8398,6 +8398,8 @@ SELECT * FROM t WHERE c1 == 1;
 
 ---- 1347
 SELECT 42;
+┌Iselects values from dummy table
+└Output field names [""]
 ┌Evaluate 42 as "",
 └Output field names [""]
 


### PR DESCRIPTION
This adress #155

For queries which have `select` without `from` clause like `select 42`. I have implemented `selectDummyPlan` which just works with the values captured by the `select.flds`. This way we don't have to refactor all places which relies on `select.from` since most are interested in `select.from.plan` which for an unintialized `joinRset` is nil( see NOTE below) we can then send the `selectDummyPlan` down the chain.

The previous failed tests are passing but there are new failing tests

```
$ go test
--- FAIL: TestMemStorage (0.64s)
        storage_test.go:356: 1348 error: internal error 052
--- FAIL: TestFileStorage (2.44s)
        storage_test.go:356: 1348 error: internal error 052
--- FAIL: TestOSFileStorage (1.82s)
        storage_test.go:356: 1348 error: internal error 052
FAIL
exit status 1
FAIL    github.com/cznic/ql     5.071s
```

I couldn't debug why these tests are failing, so I might need a pointer in the right direction here.

__NOTE__ I have just realised that `select.from` is  always not nil which makes things a bit complicated as I was expecting it to be nil for the case of missing from clause. That has forced me to use reflection to ensure the `select.from` object is not initialized.