### PR TITLE
refactor issue #155 implementation

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -2820,26 +2820,3 @@ func (r *selectDummyPlan) do(ctx *execCtx, f func(id interface{}, data []interfa
 	_, err = f(nil, r.fields)
 	return
 }
-
-type wrapFilterPlan struct {
-	*filterDefaultPlan
-}
-
-func (r *wrapFilterPlan) do(ctx *execCtx, f func(id interface{}, data []interface{}) (bool, error)) (err error) {
-	var match bool
-	err = r.filterDefaultPlan.do(ctx, func(id interface{}, data []interface{}) (bool, error) {
-		if len(data) > 0 {
-			match = true
-		}
-		return false, nil
-	})
-	if match {
-		return r.filterDefaultPlan.do(ctx, f)
-	}
-	v := make([]interface{}, len(r.fieldNames()))
-	for i := range v {
-		v[i] = ""
-	}
-	_, err = f(nil, v)
-	return
-}

--- a/ql.go
+++ b/ql.go
@@ -546,9 +546,7 @@ func (r *whereRset) plan(ctx *execCtx) (plan, error) {
 		if r.exists == exists {
 			return o, nil
 		}
-		x := value{val: false}
-		return &wrapFilterPlan{&filterDefaultPlan{o, x, nil}}, nil
-
+		return &nullPlan{fields: o.fieldNames()}, nil
 	}
 	return r.planExpr(ctx)
 }

--- a/testdata.log
+++ b/testdata.log
@@ -8412,23 +8412,17 @@ SELECT * FROM t WHERE  EXISTS ( SELECT * FROM t WHERE i == 2 ) ORDER BY i;
 
 ---- 1349
 SELECT * FROM t WHERE  EXISTS ( SELECT * FROM t WHERE i == 2 );
-┌Iterate all rows of table "t"
-└Output field names ["i"]
-┌Filter on false
+┌Iterate no rows
 └Output field names ["i"]
 
 ---- 1350
 SELECT * FROM t WHERE  EXISTS ( SELECT * FROM t WHERE i == 4 );
-┌Iterate all rows of table "t"
-└Output field names ["i"]
-┌Filter on false
+┌Iterate no rows
 └Output field names ["i"]
 
 ---- 1351
 SELECT * FROM t WHERE  NOT  EXISTS ( SELECT * FROM t WHERE i == 2 );
-┌Iterate all rows of table "t"
-└Output field names ["i"]
-┌Filter on false
+┌Iterate no rows
 └Output field names ["i"]
 
 ---- 1352

--- a/testdata.ql
+++ b/testdata.ql
@@ -15695,7 +15695,6 @@ BEGIN TRANSACTION;
 COMMIT;
 SELECT * FROM t WHERE EXISTS (SELECT * FROM t WHERE i == 2);
 |"i"
-[]
 
 -- 1350 // https://github.com/cznic/ql/issues/155
 BEGIN TRANSACTION;
@@ -15706,7 +15705,6 @@ BEGIN TRANSACTION;
 COMMIT;
 SELECT * FROM t WHERE EXISTS (SELECT * FROM t WHERE i == 4);
 |"i"
-[]
 
 -- 1351 // https://github.com/cznic/ql/issues/155
 BEGIN TRANSACTION;
@@ -15717,7 +15715,6 @@ BEGIN TRANSACTION;
 COMMIT;
 SELECT * FROM t WHERE NOT EXISTS (SELECT * FROM t WHERE i == 2);
 |"i"
-[]
 
 -- 1352 // https://github.com/cznic/ql/issues/155
 BEGIN TRANSACTION;


### PR DESCRIPTION
This is refactoring #155 after discovering the tests were  not correct.

For the case of a query  on table t with field i. If there is no row that matches. It is supposed to be represented as `|"i"` instead of

```
|"i"
[]
```

Closes #163