### PR TITLE
Add support for multiple result set (go1.8)

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -3501,3 +3501,70 @@ COMMIT;
 	}
 	wg.Wait()
 }
+
+func TestSelectDummy(t *testing.T) {
+	RegisterMemDriver()
+	db, err := sql.Open("ql-mem", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	//int
+	var i int
+	err = db.QueryRow("select 1").Scan(&i)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i != 1 {
+		t.Fatalf("expected 1 got %d", i)
+	}
+
+	i = 0
+	err = db.QueryRow("select $1", 1).Scan(&i)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i != 1 {
+		t.Fatalf("expected 1 got %d", i)
+	}
+
+	//float
+	var f float64
+	err = db.QueryRow("select 1.5").Scan(&f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f != 1.5 {
+		t.Fatalf("expected 1.0 got %f", f)
+	}
+
+	f = 0.0
+	err = db.QueryRow("select $1", 1.5).Scan(&f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f != 1.5 {
+		t.Fatalf("expected 1.5 got %f", f)
+	}
+
+	//string
+	var s string
+	msg := "foo"
+	err = db.QueryRow(`select "foo"`).Scan(&s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != msg {
+		t.Fatalf("expected %s got %s", msg, s)
+	}
+
+	s = ""
+	err = db.QueryRow("select $1", msg).Scan(&s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != msg {
+		t.Fatalf("expected %s got %s", msg, s)
+	}
+}

--- a/driver.go
+++ b/driver.go
@@ -469,7 +469,7 @@ func (r *driverRows) Next(dest []driver.Value) error {
 				switch v := xi.(type) {
 				case nil, int64, float64, bool, []byte, time.Time:
 					dest[i] = v
-				case complex64, complex128, *big.Int, *big.Rat:
+				case complex64, complex128, *big.Int, *big.Rat, idealComplex:
 					var buf bytes.Buffer
 					fmt.Fprintf(&buf, "%v", v)
 					dest[i] = buf.Bytes()
@@ -495,6 +495,12 @@ func (r *driverRows) Next(dest []driver.Value) error {
 					dest[i] = int64(v)
 				case string:
 					dest[i] = []byte(v)
+				case idealInt:
+					dest[i] = int64(v)
+				case idealUint:
+					dest[i] = int64(v)
+				case idealFloat:
+					dest[i] = float64(v)
 				default:
 					return fmt.Errorf("internal error 004")
 				}

--- a/go1.8_test.go
+++ b/go1.8_test.go
@@ -1,0 +1,74 @@
+//+build go1.8
+
+package ql
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestMultiResultSet(t *testing.T) {
+	RegisterMemDriver()
+	db, err := sql.Open("ql-mem", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	rows, err := db.Query(`select 1;select 2;select 3;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var i int
+	for rows.Next() {
+		if err := rows.Scan(&i); err != nil {
+			t.Fatal(err)
+		}
+		if i != 1 {
+			t.Fatalf("expected 1, got %d", i)
+		}
+	}
+	if !rows.NextResultSet() {
+		t.Fatal("expected more result sets", rows.Err())
+	}
+	for rows.Next() {
+		if err := rows.Scan(&i); err != nil {
+			t.Fatal(err)
+		}
+		if i != 2 {
+			t.Fatalf("expected 2, got %d", i)
+		}
+	}
+
+	// Make sure that if we ignore a result we can still query.
+
+	rows, err = db.Query("select 4; select 5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := rows.Scan(&i); err != nil {
+			t.Fatal(err)
+		}
+		if i != 4 {
+			t.Fatalf("expected 4, got %d", i)
+		}
+	}
+	if !rows.NextResultSet() {
+		t.Fatal("expected more result sets", rows.Err())
+	}
+	for rows.Next() {
+		if err := rows.Scan(&i); err != nil {
+			t.Fatal(err)
+		}
+		if i != 5 {
+			t.Fatalf("expected 5, got %d", i)
+		}
+	}
+	if rows.NextResultSet() {
+		t.Fatal("unexpected result set")
+	}
+}


### PR DESCRIPTION
Add support for multiple result set (go1.8)

This PR adds driverMultiRows which implements driver.RowsNextResultSet

This should work for both versions of Go since there is no feature specific to go1.8 used.

This is based on #166 