### PR TITLE
Fix proper  set result field names  when using join clause

### DIFF
--- a/ql.go
+++ b/ql.go
@@ -1765,23 +1765,18 @@ func (r *joinRset) plan(ctx *execCtx) (plan, error) {
 				if f != "" && nm != "" {
 					f = fmt.Sprintf("%s.%s", nm, f)
 				}
-				if nm == "" {
-					f = ""
-				}
 				fields = append(fields, f)
 			}
 		}
 		rsets[i] = q
 	}
 
-	if len(rsets) == 1 {
+	switch len(rsets) {
+	case 0:
+		return nil, nil
+	case 1:
 		return rsets[0], nil
 	}
-
-	if len(rsets) == 0 {
-		return nil, nil
-	}
-
 	right := len(rsets[len(rsets)-1].fieldNames())
 	switch r.typ {
 	case crossJoin:

--- a/testdata.log
+++ b/testdata.log
@@ -404,7 +404,7 @@ SELECT * FROM (SELECT * FROM employee;), (SELECT * FROM department;);
 │   └Output field names ["LastName" "DepartmentID"]
 │   ┌Iterate all rows of table "department"
 │   └Output field names ["DepartmentID" "DepartmentName"]
-└Output field names ["" "" "" ""]
+└Output field names ["LastName" "DepartmentID" "DepartmentID" "DepartmentName"]
 
 ---- 75
 SELECT * FROM (SELECT * FROM employee;) AS e, (SELECT * FROM department;) ORDER BY e.LastName, e.DepartmentID;
@@ -413,9 +413,9 @@ SELECT * FROM (SELECT * FROM employee;) AS e, (SELECT * FROM department;) ORDER 
 │   └Output field names ["LastName" "DepartmentID"]
 │   ┌Iterate all rows of table "department"
 │   └Output field names ["DepartmentID" "DepartmentName"]
-└Output field names ["e.LastName" "e.DepartmentID" "" ""]
+└Output field names ["e.LastName" "e.DepartmentID" "DepartmentID" "DepartmentName"]
 ┌Order by e.LastName, e.DepartmentID,
-└Output field names ["e.LastName" "e.DepartmentID" "" ""]
+└Output field names ["e.LastName" "e.DepartmentID" "DepartmentID" "DepartmentName"]
 
 ---- 76
 SELECT * FROM (SELECT * FROM employee;), (SELECT * FROM department;) AS d ORDER BY d.DepartmentID DESC;
@@ -424,9 +424,9 @@ SELECT * FROM (SELECT * FROM employee;), (SELECT * FROM department;) AS d ORDER 
 │   └Output field names ["LastName" "DepartmentID"]
 │   ┌Iterate all rows of table "department"
 │   └Output field names ["DepartmentID" "DepartmentName"]
-└Output field names ["" "" "d.DepartmentID" "d.DepartmentName"]
+└Output field names ["LastName" "DepartmentID" "d.DepartmentID" "d.DepartmentName"]
 ┌Order descending by d.DepartmentID,
-└Output field names ["" "" "d.DepartmentID" "d.DepartmentName"]
+└Output field names ["LastName" "DepartmentID" "d.DepartmentID" "d.DepartmentName"]
 
 ---- 77
 SELECT * FROM employee, (SELECT * FROM department;) ORDER BY employee.LastName;
@@ -435,9 +435,9 @@ SELECT * FROM employee, (SELECT * FROM department;) ORDER BY employee.LastName;
 │   └Output field names ["LastName" "DepartmentID"]
 │   ┌Iterate all rows of table "department"
 │   └Output field names ["DepartmentID" "DepartmentName"]
-└Output field names ["employee.LastName" "employee.DepartmentID" "" ""]
+└Output field names ["employee.LastName" "employee.DepartmentID" "DepartmentID" "DepartmentName"]
 ┌Order by employee.LastName,
-└Output field names ["employee.LastName" "employee.DepartmentID" "" ""]
+└Output field names ["employee.LastName" "employee.DepartmentID" "DepartmentID" "DepartmentName"]
 
 ---- 78
 SELECT * FROM (SELECT * FROM employee;) AS e, (SELECT * FROM department;) AS d WHERE e.DepartmentID == d.DepartmentID ORDER BY d.DepartmentName, e.LastName;
@@ -879,9 +879,9 @@ SELECT * FROM employee AS e, (SELECT * FROM department;) ORDER BY e.LastName;
 │   └Output field names ["LastName" "DepartmentID"]
 │   ┌Iterate all rows of table "department"
 │   └Output field names ["DepartmentID" "DepartmentName"]
-└Output field names ["e.LastName" "e.DepartmentID" "" ""]
+└Output field names ["e.LastName" "e.DepartmentID" "DepartmentID" "DepartmentName"]
 ┌Order by e.LastName,
-└Output field names ["e.LastName" "e.DepartmentID" "" ""]
+└Output field names ["e.LastName" "e.DepartmentID" "DepartmentID" "DepartmentName"]
 
 ---- 155
 SELECT * FROM employee AS e, (SELECT * FROM department;) AS d ORDER BY e.LastName;

--- a/testdata.ql
+++ b/testdata.ql
@@ -811,7 +811,7 @@ FROM
 	SELECT *
 	FROM department
 );
-|"", "", "", ""
+|"LastName", "DepartmentID", "DepartmentID", "DepartmentName"
 [Williams <nil> 35 Marketing]
 [Williams <nil> 34 Clerical]
 [Williams <nil> 33 Engineering]
@@ -849,7 +849,7 @@ FROM
 	FROM department
 )
 ORDER BY e.LastName, e.DepartmentID;
-|"e.LastName", "e.DepartmentID", "", ""
+|"e.LastName", "e.DepartmentID", "DepartmentID", "DepartmentName"
 [Heisenberg 33 35 Marketing]
 [Heisenberg 33 34 Clerical]
 [Heisenberg 33 33 Engineering]
@@ -887,7 +887,7 @@ FROM
 	FROM department
 ) AS d
 ORDER BY d.DepartmentID DESC;
-|"", "", "d.DepartmentID", "d.DepartmentName"
+|"LastName", "DepartmentID", "d.DepartmentID", "d.DepartmentName"
 [Rafferty 31 35 Marketing]
 [Jones 33 35 Marketing]
 [Heisenberg 33 35 Marketing]
@@ -922,7 +922,7 @@ FROM
 		FROM department
 	)
 ORDER BY employee.LastName;
-|"employee.LastName", "employee.DepartmentID", "", ""
+|"employee.LastName", "employee.DepartmentID", "DepartmentID", "DepartmentName"
 [Heisenberg 33 35 Marketing]
 [Heisenberg 33 34 Clerical]
 [Heisenberg 33 33 Engineering]
@@ -1654,7 +1654,7 @@ FROM
 	employee AS e,
 	( SELECT * FROM department)
 ORDER BY e.LastName;
-|"e.LastName", "e.DepartmentID", "", ""
+|"e.LastName", "e.DepartmentID", "DepartmentID", "DepartmentName"
 [Heisenberg 33 35 Marketing]
 [Heisenberg 33 34 Clerical]
 [Heisenberg 33 33 Engineering]


### PR DESCRIPTION
Closes #137
Context #136

This PR make sure the field names for results nested select are set properly.

Previously the names were set to empty strings .