### PR TITLE
Add support for interactive mode in ql tool

### DIFF
--- a/ql/main.go
+++ b/ql/main.go
@@ -186,9 +186,10 @@ func run(cfg *config, o *bufio.Writer, src string, db *ql.DB) (err error) {
 	defer o.Flush()
 	if cfg.interactive {
 		src = strings.TrimSpace(src)
-		if strings.HasPrefix(src, "\\") {
+		if strings.HasPrefix(src, "\\") ||
+			strings.HasPrefix(src, ".") {
 			switch src {
-			case "\\clear":
+			case "\\clear", ".clear":
 				switch runtime.GOOS {
 				case "darwin", "linux":
 					fmt.Fprintln(o, "\033[H\033[2J")
@@ -196,7 +197,7 @@ func run(cfg *config, o *bufio.Writer, src string, db *ql.DB) (err error) {
 					fmt.Fprintln(o, "clear not supported in this system")
 				}
 				return nil
-			case "\\q", "\\exit":
+			case "\\q", "\\exit", ".q", ".exit":
 				// we make sure to close the database before exiting
 				db.Close()
 				os.Exit(1)


### PR DESCRIPTION
This commit adds `-i` flag which will drop you in an interactive shell.

You can run queries as you do with normal ql tool in the interactive shell.

At the moment there are two utility commands in the ql shell.

`\clear` which will clear your terminal( This only works on linux and darwin)

`\exit` exits the interactive sjell

`\q` is an alias for `\exit`

Eveverything else is interpreted as a ql query