### PR TITLE
Evaluate field expression when selecting on dummy tables

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -803,13 +803,7 @@ func (s *selectStmt) plan(ctx *execCtx) (plan, error) { //LATER overlapping goro
 		}
 	}
 	if r == nil {
-		var fds []interface{}
-		for _, v := range s.flds {
-			if val, ok := v.expr.(value); ok {
-				fds = append(fds, val)
-			}
-		}
-		r = &selectDummyPlan{fields: fds}
+		r = &selectDummyPlan{flds: s.flds}
 	}
 	if w := s.where; w != nil {
 		if r, err = (&whereRset{expr: w.expr, src: r, sel: w.sel, exists: w.exists}).plan(ctx); err != nil {


### PR DESCRIPTION
This commit ensures the field expression is evaluated when selecting from nothing.

For instance you can

```
select 10, now();
```

This query will return a row of two values, 10 and `time.Time`.

This functionality is handy when we try to implement the pg_sleep function to slow down queries.

so we can do something like

```
select 1;select sleep(100);select 2;
 ```