### PR TITLE
Add sleep built in function

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -3682,3 +3682,43 @@ left join condition on condition.key == product_condkey;
 		}
 	}
 }
+
+func TestSleep(t *testing.T) {
+	db, err := OpenMem()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// sleep with duration
+	rst, _, err := db.run(nil, "select sleep($1);", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rs := range rst {
+		_, err = rs.FirstRow()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// sleep with an int
+	rst, _, err = db.run(nil, "select sleep(5);")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rs := range rst {
+		start := time.Now()
+		_, err := rs.FirstRow()
+		if err != nil {
+			t.Fatal(err)
+		}
+		end := time.Now().Sub(start)
+
+		// The duration should be 5 seconds
+		e := end.String()
+		if !strings.HasPrefix(e, "5.") {
+			t.Errorf("expected 5s got %s", e)
+		}
+	}
+}

--- a/builtin.go
+++ b/builtin.go
@@ -53,6 +53,7 @@ var builtin = map[string]struct {
 	"second":       {builtinSecond, 1, 1, true, false},
 	"seconds":      {builtinSeconds, 1, 1, true, false},
 	"since":        {builtinSince, 1, 1, false, false},
+	"sleep":        {builtinSleep, 1, 1, false, false},
 	"sum":          {builtinSum, 1, 1, false, true},
 	"timeIn":       {builtinTimeIn, 2, 2, true, false},
 	"weekday":      {builtinWeekday, 1, 1, true, false},
@@ -870,6 +871,26 @@ func builtinSince(arg []interface{}, ctx map[interface{}]interface{}) (v interfa
 		return time.Since(x), nil
 	default:
 		return nil, invArg(x, "since")
+	}
+}
+
+func builtinSleep(arg []interface{}, ctx map[interface{}]interface{}) (v interface{}, err error) {
+	switch x := arg[0].(type) {
+	case nil:
+		return nil, nil
+	case time.Duration:
+		time.Sleep(x)
+		return nil, nil
+	case idealInt:
+		v := time.Second * time.Duration(int64(x))
+		time.Sleep(v)
+		return nil, nil
+	case int64:
+		v := time.Second * time.Duration(x)
+		time.Sleep(v)
+		return nil, nil
+	default:
+		return nil, invArg(x, "sleep")
 	}
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -803,7 +803,7 @@ func (s *selectStmt) plan(ctx *execCtx) (plan, error) { //LATER overlapping goro
 		}
 	}
 	if r == nil {
-		r = &selectDummyPlan{flds: s.flds}
+		return &selectDummyPlan{flds: s.flds}, nil
 	}
 	if w := s.where; w != nil {
 		if r, err = (&whereRset{expr: w.expr, src: r, sel: w.sel, exists: w.exists}).plan(ctx); err != nil {

--- a/testdata.log
+++ b/testdata.log
@@ -8400,8 +8400,6 @@ SELECT * FROM t WHERE c1 == 1;
 SELECT 42;
 ┌Selects values from dummy table
 └Output field names [""]
-┌Evaluate 42 as "",
-└Output field names [""]
 
 ---- 1348
 SELECT * FROM t WHERE  EXISTS ( SELECT * FROM t WHERE i == 2 ) ORDER BY i;


### PR DESCRIPTION
This function  is useful for delaying execution. The implementation is based on `pg_sleep` which accepts a number of seconds to sleep.

```
select sleep(5);
```

will sleep 5 seconds before returning.

__APOLOGIES__ to reviewer. I had to  make three changes in defferent parts to accomodate this, the changes in ql tool were meant to help demoonstrate the use of this function like on `pg_sleep`.

```
ql -i
ql> select now(); select sleep(5) ; select now();
2017-05-11 16:18:35.06018569 +0300 EAT
<nil>
2017-05-11 16:18:40.062569337 +0300 EAT
ql>
```
Check the differece in seconds between the first result set and the third. There is still a lot to be done on ql tool.

__EDIT__: Fix typo