### PR TITLE
Support lt,gt,le,ge,ne,eq operators for blob

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ Boy van Duuren <boy@vanduuren.xyz>
 Dan Kortschak <dan.kortschak@adelaide.edu.au>
 Geofrey Ernest <geofreyernest@live.com>
 Jan Mercl <0xjnml@gmail.com>
+Michael Eisendle <michael@eisendle.me>
 OpenNota <opennota@gmail.com>
 Victor Kryukov <victor.kryukov@gmail.com>
 Viktor Kojouharov <vkojouharov@gmail.com>

--- a/doc.go
+++ b/doc.go
@@ -1089,7 +1089,7 @@
 //
 // - Rational values are comparable and ordered, in the usual way.
 //
-// - String values are comparable and ordered, lexically byte-wise.
+// - String and Blob values are comparable and ordered, lexically byte-wise.
 //
 // - Time values are comparable and ordered.
 //

--- a/expr.go
+++ b/expr.go
@@ -5,6 +5,7 @@
 package ql
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"regexp"
@@ -779,6 +780,13 @@ func (o *binaryOperation) eval(execCtx *execCtx, ctx map[interface{}]interface{}
 			default:
 				return invOp2(x, y, op)
 			}
+		case []byte:
+			switch y := b.(type) {
+			case []byte:
+				return bytes.Compare(x, y) == 0, nil
+			default:
+				return invOp2(x, y, op)
+			}
 		default:
 			return invOp2(a, b, op)
 		}
@@ -927,6 +935,13 @@ func (o *binaryOperation) eval(execCtx *execCtx, ctx map[interface{}]interface{}
 			switch y := b.(type) {
 			case time.Time:
 				return x.Before(y), nil
+			default:
+				return invOp2(x, y, op)
+			}
+		case []byte:
+			switch y := b.(type) {
+			case []byte:
+				return bytes.Compare(x, y) < 0, nil
 			default:
 				return invOp2(x, y, op)
 			}
@@ -1081,6 +1096,13 @@ func (o *binaryOperation) eval(execCtx *execCtx, ctx map[interface{}]interface{}
 			default:
 				return invOp2(x, y, op)
 			}
+		case []byte:
+			switch y := b.(type) {
+			case []byte:
+				return bytes.Compare(x, y) <= 0, nil
+			default:
+				return invOp2(x, y, op)
+			}
 		default:
 			return invOp2(a, b, op)
 		}
@@ -1229,6 +1251,13 @@ func (o *binaryOperation) eval(execCtx *execCtx, ctx map[interface{}]interface{}
 			switch y := b.(type) {
 			case time.Time:
 				return x.After(y) || x.Equal(y), nil
+			default:
+				return invOp2(x, y, op)
+			}
+		case []byte:
+			switch y := b.(type) {
+			case []byte:
+				return bytes.Compare(x, y) >= 0, nil
 			default:
 				return invOp2(x, y, op)
 			}
@@ -1403,6 +1432,13 @@ func (o *binaryOperation) eval(execCtx *execCtx, ctx map[interface{}]interface{}
 			default:
 				return invOp2(x, y, op)
 			}
+		case []byte:
+			switch y := b.(type) {
+			case []byte:
+				return bytes.Compare(x, y) != 0, nil
+			default:
+				return invOp2(x, y, op)
+			}
 		default:
 			return invOp2(a, b, op)
 		}
@@ -1571,6 +1607,13 @@ func (o *binaryOperation) eval(execCtx *execCtx, ctx map[interface{}]interface{}
 			switch y := b.(type) {
 			case time.Time:
 				return x.Equal(y), nil
+			default:
+				return invOp2(x, y, op)
+			}
+		case []byte:
+			switch y := b.(type) {
+			case []byte:
+				return bytes.Compare(x, y) == 0, nil
 			default:
 				return invOp2(x, y, op)
 			}


### PR DESCRIPTION
It utilizes bytes.Compare from the standard library. The operators lt, gt, le and ge are only useful when comparing blobs of the same size, as they will return false otherwise. A use case for this is f.i. when storing IP addresses as blobs, to compare them and/or select ranges.